### PR TITLE
feat: vol.1のプロパティが消える問題対応

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,5 +63,5 @@ crashlytics-build.properties
 Assets/PackageMakerWindowData.asset*
 .idea
 .vscode
-UserSettings
-ClientSimStorage
+/UserSettings/
+/ClientSimStorage/

--- a/Packages/net.omoi0kane.platform-magazine/Runtime/Platform_Vol1 Variant.prefab
+++ b/Packages/net.omoi0kane.platform-magazine/Runtime/Platform_Vol1 Variant.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1001 &7050140786863243452
+--- !u!1001 &1451267541318317004
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -21,7 +21,7 @@ PrefabInstance:
     - target: {fileID: 1933533690728418644, guid: 529a5a452f24f0043a35f2d68c093244,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.149
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1933533690728418644, guid: 529a5a452f24f0043a35f2d68c093244,
         type: 3}
@@ -63,17 +63,22 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2636507416816953204, guid: 529a5a452f24f0043a35f2d68c093244,
-        type: 3}
-      propertyPath: m_Texture
-      value: 
-      objectReference: {fileID: 2800000, guid: a2c47d6ed1f43024e93b692959a63141, type: 3}
     - target: {fileID: 2809101995262594763, guid: 529a5a452f24f0043a35f2d68c093244,
         type: 3}
       propertyPath: serializationData.Prefab
       value: 
       objectReference: {fileID: 2809101995262594763, guid: 529a5a452f24f0043a35f2d68c093244,
         type: 3}
+    - target: {fileID: 3546902071610693837, guid: 529a5a452f24f0043a35f2d68c093244,
+        type: 3}
+      propertyPath: title
+      value: Platform Vol.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3546902071610693837, guid: 529a5a452f24f0043a35f2d68c093244,
+        type: 3}
+      propertyPath: author
+      value: "Platform\u7DE8\u96C6\u90E8"
+      objectReference: {fileID: 0}
     - target: {fileID: 3546902071610693837, guid: 529a5a452f24f0043a35f2d68c093244,
         type: 3}
       propertyPath: pageTextures.Array.size
@@ -195,153 +200,17 @@ PrefabInstance:
       propertyPath: pageTextures.Array.data[21]
       value: 
       objectReference: {fileID: 2800000, guid: 64236e8a4296a9d4bb301fe5da92d615, type: 3}
-    - target: {fileID: 3612010453759278554, guid: 529a5a452f24f0043a35f2d68c093244,
-        type: 3}
-      propertyPath: m_Texture
-      value: 
-      objectReference: {fileID: 2800000, guid: 212c89e47c4a2494ba993daea0372062, type: 3}
-    - target: {fileID: 3771212509931846561, guid: 529a5a452f24f0043a35f2d68c093244,
-        type: 3}
-      propertyPath: m_Texture
-      value: 
-      objectReference: {fileID: 2800000, guid: b0761df0260b8154f8d2a9d473e46e64, type: 3}
     - target: {fileID: 4117247062890069744, guid: 529a5a452f24f0043a35f2d68c093244,
         type: 3}
       propertyPath: serializationData.Prefab
       value: 
       objectReference: {fileID: 4117247062890069744, guid: 529a5a452f24f0043a35f2d68c093244,
         type: 3}
-    - target: {fileID: 5491621900972205410, guid: 529a5a452f24f0043a35f2d68c093244,
-        type: 3}
-      propertyPath: m_Texture
-      value: 
-      objectReference: {fileID: 2800000, guid: e1cb8e519ee941a45983c43e6eb71b5f, type: 3}
     - target: {fileID: 5706560644483027543, guid: 529a5a452f24f0043a35f2d68c093244,
         type: 3}
       propertyPath: m_Name
-      value: Platform_Vol1 Variant
+      value: Platform_vol1 Variant
       objectReference: {fileID: 0}
-    - target: {fileID: 6187791773783392659, guid: 529a5a452f24f0043a35f2d68c093244,
-        type: 3}
-      propertyPath: pageTextures.Array.size
-      value: 22
-      objectReference: {fileID: 0}
-    - target: {fileID: 6187791773783392659, guid: 529a5a452f24f0043a35f2d68c093244,
-        type: 3}
-      propertyPath: serializationData.Prefab
-      value: 
-      objectReference: {fileID: 6187791773783392659, guid: 529a5a452f24f0043a35f2d68c093244,
-        type: 3}
-    - target: {fileID: 6187791773783392659, guid: 529a5a452f24f0043a35f2d68c093244,
-        type: 3}
-      propertyPath: pageTextures.Array.data[0]
-      value: 
-      objectReference: {fileID: 2800000, guid: e1cb8e519ee941a45983c43e6eb71b5f, type: 3}
-    - target: {fileID: 6187791773783392659, guid: 529a5a452f24f0043a35f2d68c093244,
-        type: 3}
-      propertyPath: pageTextures.Array.data[1]
-      value: 
-      objectReference: {fileID: 2800000, guid: 212c89e47c4a2494ba993daea0372062, type: 3}
-    - target: {fileID: 6187791773783392659, guid: 529a5a452f24f0043a35f2d68c093244,
-        type: 3}
-      propertyPath: pageTextures.Array.data[2]
-      value: 
-      objectReference: {fileID: 2800000, guid: b0761df0260b8154f8d2a9d473e46e64, type: 3}
-    - target: {fileID: 6187791773783392659, guid: 529a5a452f24f0043a35f2d68c093244,
-        type: 3}
-      propertyPath: pageTextures.Array.data[3]
-      value: 
-      objectReference: {fileID: 2800000, guid: a2c47d6ed1f43024e93b692959a63141, type: 3}
-    - target: {fileID: 6187791773783392659, guid: 529a5a452f24f0043a35f2d68c093244,
-        type: 3}
-      propertyPath: pageTextures.Array.data[4]
-      value: 
-      objectReference: {fileID: 2800000, guid: bf7fc63c632c39446bd3d2aaeb44046a, type: 3}
-    - target: {fileID: 6187791773783392659, guid: 529a5a452f24f0043a35f2d68c093244,
-        type: 3}
-      propertyPath: pageTextures.Array.data[5]
-      value: 
-      objectReference: {fileID: 2800000, guid: ba1e53a15bca3464c86e06205cdd7b47, type: 3}
-    - target: {fileID: 6187791773783392659, guid: 529a5a452f24f0043a35f2d68c093244,
-        type: 3}
-      propertyPath: pageTextures.Array.data[6]
-      value: 
-      objectReference: {fileID: 2800000, guid: 997873a6b1c909f4aad510b7edefe117, type: 3}
-    - target: {fileID: 6187791773783392659, guid: 529a5a452f24f0043a35f2d68c093244,
-        type: 3}
-      propertyPath: pageTextures.Array.data[7]
-      value: 
-      objectReference: {fileID: 2800000, guid: d9dba4a4da468fa48b128c619ca76bc3, type: 3}
-    - target: {fileID: 6187791773783392659, guid: 529a5a452f24f0043a35f2d68c093244,
-        type: 3}
-      propertyPath: pageTextures.Array.data[8]
-      value: 
-      objectReference: {fileID: 2800000, guid: a8d2bca7b8f5a9a49a5e7744ca436b8c, type: 3}
-    - target: {fileID: 6187791773783392659, guid: 529a5a452f24f0043a35f2d68c093244,
-        type: 3}
-      propertyPath: pageTextures.Array.data[9]
-      value: 
-      objectReference: {fileID: 2800000, guid: 805a65b8ebe33a34f963ac8374cc6aa6, type: 3}
-    - target: {fileID: 6187791773783392659, guid: 529a5a452f24f0043a35f2d68c093244,
-        type: 3}
-      propertyPath: pageTextures.Array.data[10]
-      value: 
-      objectReference: {fileID: 2800000, guid: aa8d598de1fb4fa429cffbaa00699e1c, type: 3}
-    - target: {fileID: 6187791773783392659, guid: 529a5a452f24f0043a35f2d68c093244,
-        type: 3}
-      propertyPath: pageTextures.Array.data[11]
-      value: 
-      objectReference: {fileID: 2800000, guid: c032cdc74df50a94ab5b669ef6b20103, type: 3}
-    - target: {fileID: 6187791773783392659, guid: 529a5a452f24f0043a35f2d68c093244,
-        type: 3}
-      propertyPath: pageTextures.Array.data[12]
-      value: 
-      objectReference: {fileID: 2800000, guid: b491a9351f41966499b5feb59e940ea6, type: 3}
-    - target: {fileID: 6187791773783392659, guid: 529a5a452f24f0043a35f2d68c093244,
-        type: 3}
-      propertyPath: pageTextures.Array.data[13]
-      value: 
-      objectReference: {fileID: 2800000, guid: 89a14ba204cf8944d831cf9d148f14d2, type: 3}
-    - target: {fileID: 6187791773783392659, guid: 529a5a452f24f0043a35f2d68c093244,
-        type: 3}
-      propertyPath: pageTextures.Array.data[14]
-      value: 
-      objectReference: {fileID: 2800000, guid: 45c481bb15aadaf488a52aa4cd046df8, type: 3}
-    - target: {fileID: 6187791773783392659, guid: 529a5a452f24f0043a35f2d68c093244,
-        type: 3}
-      propertyPath: pageTextures.Array.data[15]
-      value: 
-      objectReference: {fileID: 2800000, guid: 8bd10e21f30963344901595970bc2b06, type: 3}
-    - target: {fileID: 6187791773783392659, guid: 529a5a452f24f0043a35f2d68c093244,
-        type: 3}
-      propertyPath: pageTextures.Array.data[16]
-      value: 
-      objectReference: {fileID: 2800000, guid: d72974b82bf129f408f895c81a13237a, type: 3}
-    - target: {fileID: 6187791773783392659, guid: 529a5a452f24f0043a35f2d68c093244,
-        type: 3}
-      propertyPath: pageTextures.Array.data[17]
-      value: 
-      objectReference: {fileID: 2800000, guid: f06532511dc52954180b7098313ec54f, type: 3}
-    - target: {fileID: 6187791773783392659, guid: 529a5a452f24f0043a35f2d68c093244,
-        type: 3}
-      propertyPath: pageTextures.Array.data[18]
-      value: 
-      objectReference: {fileID: 2800000, guid: f78897cbd7078ba4f84533c3b7365336, type: 3}
-    - target: {fileID: 6187791773783392659, guid: 529a5a452f24f0043a35f2d68c093244,
-        type: 3}
-      propertyPath: pageTextures.Array.data[19]
-      value: 
-      objectReference: {fileID: 2800000, guid: 81d615522efd6bc49879fd529b7b20df, type: 3}
-    - target: {fileID: 6187791773783392659, guid: 529a5a452f24f0043a35f2d68c093244,
-        type: 3}
-      propertyPath: pageTextures.Array.data[20]
-      value: 
-      objectReference: {fileID: 2800000, guid: b8e8e0a3d0ca3fe41bbccedcc0b79ade, type: 3}
-    - target: {fileID: 6187791773783392659, guid: 529a5a452f24f0043a35f2d68c093244,
-        type: 3}
-      propertyPath: pageTextures.Array.data[21]
-      value: 
-      objectReference: {fileID: 2800000, guid: 64236e8a4296a9d4bb301fe5da92d615, type: 3}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []


### PR DESCRIPTION
新規PJにvpmで入れるとプロパティが消えてしまう。
Udon Magazine 0.1.5で作ったprefab variantであったことが原因と推定、0.2.0を前提にprefab variantを再作成。